### PR TITLE
Fix for the ImportError WebSocketHandler

### DIFF
--- a/bin/wsshd
+++ b/bin/wsshd
@@ -62,7 +62,7 @@ def connect(hostname, username):
 if __name__ == '__main__':
     import argparse
     from gevent.pywsgi import WSGIServer
-    from geventwebsocket import WebSocketHandler
+    from geventwebsocket.handler import WebSocketHandler
     from jinja2 import FileSystemLoader
     import os
 


### PR DESCRIPTION
Fixed ImportError: cannot import name WebSocketHandler
with gevent-websocket 0.9.1
