### PR TITLE
Fix event listener loss on terminal reset.

### DIFF
--- a/wssh/static/term.js
+++ b/wssh/static/term.js
@@ -131,7 +131,8 @@ function Terminal(cols, rows, handler) {
   this.rows = rows || Terminal.geometry[1];
 
   if (handler) {
-    this.on('data', handler);
+    this.dataHandler = handler;
+    this.on('data', this.dataHandler);
   }
 
   this.ybase = 0;
@@ -2432,7 +2433,7 @@ Terminal.prototype.reverseIndex = function() {
 
 // ESC c Full Reset (RIS).
 Terminal.prototype.reset = function() {
-  Terminal.call(this, this.cols, this.rows);
+  Terminal.call(this, this.cols, this.rows, this.dataHandler);
   this.refresh(0, this.rows - 1);
 };
 


### PR DESCRIPTION
Terminal reset causes _events to be cleared. This commit retains the external data handler; although it may be desirable to rework the code to retain all event listeners.