### PR TITLE
Decode to UTF-8 before loading the JSON

### DIFF
--- a/wssh/server.py
+++ b/wssh/server.py
@@ -112,6 +112,7 @@ class WSSHBridge(object):
                 data = self._websocket.receive()
                 if not data:
                     return
+                data = data.encode("utf-8")
                 data = json.loads(str(data))
                 if 'resize' in data:
                     channel.resize_pty(


### PR DESCRIPTION
Hi!

If the data is not being encoded to UTF-8 the bridge closes the connection because an unexpected exception. This could be easily reproduced sending `{"data":"ñ"}` via websocket.