### PR TITLE
Add an option to use an already connected Paramiko instance

### DIFF
--- a/wssh/server.py
+++ b/wssh/server.py
@@ -105,6 +105,11 @@ class WSSHBridge(object):
             self._websocket.send(json.dumps({'error': e.message or str(e)}))
             raise
 
+    def attach_open_session(self, ssh_client):
+        self.close()
+        self._ssh = ssh_client
+
+
     def _forward_inbound(self, channel):
         """ Forward inbound traffic (websockets -> ssh) """
         try:


### PR DESCRIPTION
This uses dependency injection to add Paramiko, so a user could connect to her server using parameters not contempled in the `open` method.